### PR TITLE
Added status badges

### DIFF
--- a/.github/workflows/release-java-library.yaml
+++ b/.github/workflows/release-java-library.yaml
@@ -1,4 +1,4 @@
-name: Release CI
+name: Release CI (java lib)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-tarball.yaml
+++ b/.github/workflows/release-tarball.yaml
@@ -1,4 +1,4 @@
-name: Release CI
+name: Release CI (tarball)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # central-uploader
+
+[![Release CI](https://github.com/canonical/central-uploader/actions/workflows/release-tarball.yaml/badge.svg)](https://github.com/canonical/central-uploader/actions/workflows/release-tarball.yaml)
+[![Release CI](https://github.com/canonical/central-uploader/actions/workflows/release-java-library.yaml/badge.svg)](https://github.com/canonical/central-uploader/actions/workflows/release-java-library.yaml)
+[![Tests](https://github.com/canonical/central-uploader/actions/workflows/ci.yaml/badge.svg)](https://github.com/canonical/central-uploader/actions/workflows/ci.yaml)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # central-uploader
 
-[![Release CI](https://github.com/canonical/central-uploader/actions/workflows/release-tarball.yaml/badge.svg)](https://github.com/canonical/central-uploader/actions/workflows/release-tarball.yaml)
-[![Release CI](https://github.com/canonical/central-uploader/actions/workflows/release-java-library.yaml/badge.svg)](https://github.com/canonical/central-uploader/actions/workflows/release-java-library.yaml)
+[![Release CI (tarball)](https://github.com/canonical/central-uploader/actions/workflows/release-tarball.yaml/badge.svg)](https://github.com/canonical/central-uploader/actions/workflows/release-tarball.yaml)
+[![Release CI (java-lib)](https://github.com/canonical/central-uploader/actions/workflows/release-java-library.yaml/badge.svg)](https://github.com/canonical/central-uploader/actions/workflows/release-java-library.yaml)
 [![Tests](https://github.com/canonical/central-uploader/actions/workflows/ci.yaml/badge.svg)](https://github.com/canonical/central-uploader/actions/workflows/ci.yaml)


### PR DESCRIPTION
Adding some workflow status badges to display repo status in the [Charm Engineering Releases](https://releases.juju.is/?team=Data) overview.