### PR TITLE
fix: CI file was invalid

### DIFF
--- a/.github/workflows/check-new-releases-non-java.yaml
+++ b/.github/workflows/check-new-releases-non-java.yaml
@@ -118,7 +118,7 @@ jobs:
             --tarball-pattern ${{ inputs.tarball-regex }} \
             --repository-owner canonical \
             --project-name ${{ github.event.repository.name }} \
-            --series ${{ inputs.series }}
+            --series ${{ inputs.series }} \
             --architecture ${{ inputs.architecture }}
           
           cd ${{ env.OUTPUT_DIR }};

--- a/.github/workflows/release-non-java-tarball.yaml
+++ b/.github/workflows/release-non-java-tarball.yaml
@@ -5,10 +5,11 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: '53 0 * * *' # Daily at 00:53 UTC
   workflow_call:
+  pull_request:
+
 
 
 jobs:

--- a/.github/workflows/release-non-java-tarball.yaml
+++ b/.github/workflows/release-non-java-tarball.yaml
@@ -8,7 +8,6 @@ on:
   schedule:
     - cron: '53 0 * * *' # Daily at 00:53 UTC
   workflow_call:
-  pull_request:
 
 
 


### PR DESCRIPTION
Some runs such as [this one](https://github.com/canonical/central-uploader/actions/runs/17994071037/job/51189861491) where failing.

This was not due to any logic issue in the software,  but a missing backslash in the CI file.

This PR fixes that.