### PR TITLE
fix: file not found bug for <500 MB releases

### DIFF
--- a/uploader/launchpad_release.py
+++ b/uploader/launchpad_release.py
@@ -124,7 +124,7 @@ def get_tarball_files(
         files = list(Path.cwd().glob(f"{tarball_path.name}*"))
         logger.debug(f"Number of files: {len(files)}")
     else:
-        shutil.move(tarball_path.absolute(), "./")
+        shutil.copy(tarball_path.absolute(), "./")
         files.append(Path(f"./{tarball_path.name}"))
 
     return files

--- a/uploader/launchpad_release.py
+++ b/uploader/launchpad_release.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+import shutil
 import sys
 from argparse import ArgumentParser, Namespace
 from datetime import datetime
@@ -123,7 +124,8 @@ def get_tarball_files(
         files = list(Path.cwd().glob(f"{tarball_path.name}*"))
         logger.debug(f"Number of files: {len(files)}")
     else:
-        files.append(tarball_path)
+        shutil.move(tarball_path.absolute(), "./")
+        files.append(Path(f"./{tarball_path.name}"))
 
     return files
 


### PR DESCRIPTION
This bug was probably introduced here: https://github.com/canonical/central-uploader/pull/43

Sample failed run:

https://github.com/canonical/central-uploader/actions/runs/27755174893

