### PR TITLE
Add NiFi tests and product release

### DIFF
--- a/.github/workflows/test-nifi.yaml
+++ b/.github/workflows/test-nifi.yaml
@@ -8,7 +8,6 @@ on:
         description: "Comma-separated list of branches to test"
         required: true
         default: "lp-2.10.0"
-  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/test-nifi.yaml
+++ b/.github/workflows/test-nifi.yaml
@@ -79,7 +79,9 @@ jobs:
         env:
           USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          ARTIFACTORY_URL: ${{ secrets.NIFI_ARTIFACTORY_URL }}
+          # Before merge: delete the hardcoded line below and uncomment this one.
+          # ARTIFACTORY_URL: ${{ secrets.NIFI_ARTIFACTORY_URL }}
+          ARTIFACTORY_URL: "https://canonical.jfrog.io/artifactory/dataplatform-nifi-staging/"
           CORE_MODULES: "nifi-commons/nifi-utils,nifi-commons/nifi-record,nifi-commons/nifi-expression-language,nifi-commons/nifi-record-path,nifi-framework-bundle/nifi-framework/nifi-framework-core"
         run: |
           echo "Java:"; java -version
@@ -98,10 +100,10 @@ jobs:
           mkdir -p logs
 
           echo "### Building core modules (-DskipTests) ###"
-          ./mvnw -B -T1C -DskipTests -Drat.skip=true -pl "${CORE_MODULES}" -am install
+          ./mvnw -B -T1C -U -DskipTests -Drat.skip=true -pl "${CORE_MODULES}" -am install
 
           echo "### Running Layer 1 unit tests ###"
-          ./mvnw -B test -fn -pl "${CORE_MODULES}" 2>&1 | tee "logs/logs-${{ steps.uuid.outputs.uuid }}.out"
+          ./mvnw -B -U test -fn -pl "${CORE_MODULES}" 2>&1 | tee "logs/logs-${{ steps.uuid.outputs.uuid }}.out"
 
           zip -r "ie-tests/logs-${{ steps.uuid.outputs.uuid }}.zip" logs
 

--- a/.github/workflows/test-nifi.yaml
+++ b/.github/workflows/test-nifi.yaml
@@ -1,0 +1,142 @@
+name: Run NiFi integration tests
+
+on:
+  workflow_call:
+  workflow_dispatch:
+    inputs:
+      branches:
+        description: "Comma-separated list of branches to test"
+        required: true
+        default: "release-2.10.0-ubuntu0"
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  prepare_matrix:
+    name: Prepare matrix
+    runs-on: ubuntu-24.04
+    steps:
+      - id: setup_matrix
+        run: |
+          input="${{ inputs.branches || 'release-2.10.0-ubuntu0' }}"
+          echo "matrix=[\"${input//,/\",\"}\"]" >> $GITHUB_OUTPUT
+          echo "[\"${input//,/\",\"}\"]"
+    outputs:
+      matrix: ${{ steps.setup_matrix.outputs.matrix }}
+
+  test_nifi:
+    needs: prepare_matrix
+    runs-on: ["self-hosted-linux-amd64-jammy-xlarge"]
+    timeout-minutes: 1440
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{fromJson(needs.prepare_matrix.outputs.matrix)}}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Install dependencies
+        run: |
+          sudo snap install yq
+          sudo apt-get update
+          sudo apt-get -y install zip
+
+      - name: ssh agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_KEY }}
+
+      - name: Clone repo
+        run: |
+          ssh-keyscan -t rsa git.launchpad.net >> ~/.ssh/known_hosts
+          echo "cloning..."
+          git clone --progress --verbose ${{ secrets.REPO_NIFI_URL }}
+          echo "cloned!"
+          cp -r ie-tests charmed-nifi
+
+      - name: Generate uuid
+        id: uuid
+        timeout-minutes: 5
+        run: echo "uuid=$(uuidgen)" >> $GITHUB_OUTPUT
+
+      - name: Setup maven credential
+        run: |
+          echo "Setup custom settings.xml"
+          mkdir -p ~/.m2
+          mv ie-tests/settings.xml ~/.m2/settings.xml
+
+      - name: Run tests
+        timeout-minutes: 600
+        env:
+          USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          ARTIFACTORY_URL: ${{ secrets.NIFI_ARTIFACTORY_URL }}
+          CORE_MODULES: "nifi-commons/nifi-utils,nifi-commons/nifi-record,nifi-commons/nifi-expression-language,nifi-commons/nifi-record-path,nifi-framework-bundle/nifi-framework/nifi-framework-core"
+        run: |
+          echo "Java:"; java -version
+          cd charmed-nifi
+
+          branch=${{ matrix.branch }}
+          [ -z "$branch" ] && branch="release-2.10.0-ubuntu0"
+          echo "Branch to test: $branch"
+          git checkout "$branch"
+          ./mvnw -version
+
+          echo "ie-tests/*" >> .rat-excludes
+          echo "**/ie-tests/*" >> .rat-excludes
+          echo "lp/*" >> .rat-excludes
+
+          mkdir -p logs
+
+          echo "### Building core modules (-DskipTests) ###"
+          ./mvnw -B -T1C -DskipTests -Drat.skip=true -pl "${CORE_MODULES}" -am install
+
+          echo "### Running Layer 1 unit tests ###"
+          ./mvnw -B test -fn -pl "${CORE_MODULES}" 2>&1 | tee "logs/logs-${{ steps.uuid.outputs.uuid }}.out"
+
+          zip -r "ie-tests/logs-${{ steps.uuid.outputs.uuid }}.zip" logs
+
+      - name: Upload locally built artifact
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: integration-test-logs-${{ steps.uuid.outputs.uuid }}
+          path: charmed-nifi/ie-tests/logs-${{ steps.uuid.outputs.uuid }}.zip
+
+  validation:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: test_nifi
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Checkout results
+        uses: actions/download-artifact@v4
+        with:
+          path: results/
+          pattern: integration-test-logs-*
+          merge-multiple: true
+      - name: Install python dependencies
+        run: pip install -r requirements.txt
+      - name: Print results
+        run: |
+          python3 -m ie-tests.validate_nifi -a "results/"
+          echo "Analysis finished"
+      - name: Compress logs
+        run: |
+          zip -r all-results.zip results
+          echo "END"
+      - name: Upload all tests logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-logs-uuid
+          path: all-results.zip

--- a/.github/workflows/test-nifi.yaml
+++ b/.github/workflows/test-nifi.yaml
@@ -7,7 +7,7 @@ on:
       branches:
         description: "Comma-separated list of branches to test"
         required: true
-        default: "release-2.10.0-ubuntu0"
+        default: "lp-2.10.0"
   pull_request:
 
 permissions:
@@ -20,7 +20,7 @@ jobs:
     steps:
       - id: setup_matrix
         run: |
-          input="${{ inputs.branches || 'release-2.10.0-ubuntu0' }}"
+          input="${{ inputs.branches || 'lp-2.10.0' }}"
           echo "matrix=[\"${input//,/\",\"}\"]" >> $GITHUB_OUTPUT
           echo "[\"${input//,/\",\"}\"]"
     outputs:
@@ -46,7 +46,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo snap install yq
           sudo apt-get update
           sudo apt-get -y install zip
 
@@ -79,9 +78,7 @@ jobs:
         env:
           USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          # Before merge: delete the hardcoded line below and uncomment this one.
-          # ARTIFACTORY_URL: ${{ secrets.NIFI_ARTIFACTORY_URL }}
-          ARTIFACTORY_URL: "https://canonical.jfrog.io/artifactory/dataplatform-nifi-staging/"
+          ARTIFACTORY_URL: ${{ secrets.NIFI_ARTIFACTORY_URL }}
           CORE_MODULES: "nifi-commons/nifi-utils,nifi-commons/nifi-record,nifi-commons/nifi-expression-language,nifi-commons/nifi-record-path,nifi-commons/nifi-security-crypto-key,nifi-commons/nifi-property-encryptor,nifi-commons/nifi-security-cert,nifi-commons/nifi-security-ssl,nifi-framework-bundle/nifi-framework/nifi-framework-core"
           SUITE: "nifi-system-tests/nifi-system-test-suite"
           # single-node smoke do not keep clustering/stateless/python
@@ -91,7 +88,7 @@ jobs:
           cd charmed-nifi
 
           branch=${{ matrix.branch }}
-          [ -z "$branch" ] && branch="release-2.10.0-ubuntu0"
+          [ -z "$branch" ] && branch="lp-2.10.0"
           echo "Branch to test: $branch"
           git checkout "$branch"
           ./mvnw -version

--- a/.github/workflows/test-nifi.yaml
+++ b/.github/workflows/test-nifi.yaml
@@ -83,114 +83,43 @@ jobs:
           # ARTIFACTORY_URL: ${{ secrets.NIFI_ARTIFACTORY_URL }}
           ARTIFACTORY_URL: "https://canonical.jfrog.io/artifactory/dataplatform-nifi-staging/"
           CORE_MODULES: "nifi-commons/nifi-utils,nifi-commons/nifi-record,nifi-commons/nifi-expression-language,nifi-commons/nifi-record-path,nifi-commons/nifi-security-crypto-key,nifi-commons/nifi-property-encryptor,nifi-commons/nifi-security-cert,nifi-commons/nifi-security-ssl,nifi-framework-bundle/nifi-framework/nifi-framework-core"
-        run: |
-          echo "Java:"; java -version
-          cd charmed-nifi
-
-          branch=${{ matrix.branch }}
-          [ -z "$branch" ] && branch="release-2.10.0-ubuntu0"
-          echo "Branch to test: $branch"
-          git checkout "$branch"
-          ./mvnw -version
-
-          echo "ie-tests/*" >> .rat-excludes
-          echo "**/ie-tests/*" >> .rat-excludes
-          echo "lp/*" >> .rat-excludes
-
-          mkdir -p logs
-
-          echo "### Building core modules (-DskipTests) ###"
-          ./mvnw -B -T1C -U -DskipTests -Drat.skip=true -pl "${CORE_MODULES}" -am install
-
-          echo "### Running Layer 1 unit tests ###"
-          ./mvnw -B -U test -fn -pl "${CORE_MODULES}" 2>&1 | tee "logs/logs-${{ steps.uuid.outputs.uuid }}.out"
-
-          zip -r "ie-tests/logs-${{ steps.uuid.outputs.uuid }}.zip" logs
-
-      - name: Upload locally built artifact
-        uses: actions/upload-artifact@v4
-        continue-on-error: true
-        with:
-          name: integration-test-logs-${{ steps.uuid.outputs.uuid }}
-          path: charmed-nifi/ie-tests/logs-${{ steps.uuid.outputs.uuid }}.zip
-
-  # Layer 2 — single-node system/integration smoke: builds NiFi and boots real instances
-  # to run flows (maven-failsafe *IT). Separate job so its weight/flakiness can't mask
-  # Layer 1. Curated single-node set only — clustering/stateless/python ITs are excluded
-  # (the rock is single-node, so those are zero-signal and the flakiest part of the suite).
-  system_tests:
-    needs: prepare_matrix
-    runs-on: ["self-hosted-linux-amd64-jammy-xlarge"]
-    timeout-minutes: 1440
-    strategy:
-      fail-fast: false
-      matrix:
-        branch: ${{fromJson(needs.prepare_matrix.outputs.matrix)}}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: "21"
-      - name: Install dependencies
-        run: |
-          sudo snap install yq
-          sudo apt-get update
-          sudo apt-get -y install zip
-      - name: ssh agent
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_KEY }}
-      - name: Clone repo
-        run: |
-          ssh-keyscan -t rsa git.launchpad.net >> ~/.ssh/known_hosts
-          git clone --progress --verbose ${{ secrets.REPO_NIFI_URL }}
-          cp -r ie-tests charmed-nifi
-      - name: Generate uuid
-        id: uuid
-        timeout-minutes: 5
-        run: echo "uuid=$(uuidgen)" >> $GITHUB_OUTPUT
-      - name: Setup maven credential
-        run: |
-          mkdir -p ~/.m2
-          mv ie-tests/settings.xml ~/.m2/settings.xml
-      - name: Run system tests
-        timeout-minutes: 600
-        env:
-          USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-          # TEMP staging URL (same as Layer 1) — revert to secrets.NIFI_ARTIFACTORY_URL before merge.
-          ARTIFACTORY_URL: "https://canonical.jfrog.io/artifactory/dataplatform-nifi-staging/"
           SUITE: "nifi-system-tests/nifi-system-test-suite"
-          # Absolute-necessary single-node smoke: boot NiFi + run basic processor flows.
-          # Widen as it stabilises; keep clustering/stateless/python OUT.
+          # single-node smoke do not keep clustering/stateless/python
           IT_TESTS: "RunOnceIT,RetryIT,ProcessorDynamicPropertiesIT,VerifiableProcessorSystemIT"
         run: |
           echo "Java:"; java -version
           cd charmed-nifi
+
           branch=${{ matrix.branch }}
           [ -z "$branch" ] && branch="release-2.10.0-ubuntu0"
           echo "Branch to test: $branch"
           git checkout "$branch"
           ./mvnw -version
+
           echo "ie-tests/*" >> .rat-excludes
           echo "**/ie-tests/*" >> .rat-excludes
           echo "lp/*" >> .rat-excludes
+
           mkdir -p logs
 
-          echo "### Building the system-test-suite + its NiFi deps (-DskipTests) ###"
-          ./mvnw -B -T1C -U -DskipTests -Drat.skip=true -pl "${SUITE}" -am install
+          # Build core modules + the system-test suite ONCE (no tests) — one clone, one build,
+          # reused by both layers (flink's build-once-then-test-groups pattern).
+          echo "### Building core + system-test suite (-DskipTests) ###"
+          ./mvnw -B -T1C -U -DskipTests -Drat.skip=true -pl "${CORE_MODULES},${SUITE}" -am install
 
-          echo "### Running Layer 2 single-node integration smoke ###"
-          # failsafe *IT tests; -fn so the validator sees all results; JVM capped for the forks.
+          # Layer 1 — unit tests on core modules.
+          echo "### Layer 1: core unit tests ###"
+          ./mvnw -B -U test -fn -pl "${CORE_MODULES}" 2>&1 | tee "logs/logs-${{ steps.uuid.outputs.uuid }}-layer1.out"
+
+          # Layer 2 — single-node system integration smoke (boots real NiFi). Best-effort:
+          # '|| true' keeps a Layer 2 build/staging failure from dropping Layer 1's results.
+          echo "### Layer 2: single-node system integration smoke ###"
           ./mvnw -B -U -fn verify -pl "${SUITE}" \
-            -Dit.test="${IT_TESTS}" -DfailIfNoTests=false \
-            -DargLine="-Xmx2g" \
-            2>&1 | tee "logs/logs-${{ steps.uuid.outputs.uuid }}-systest.out"
+            -Dit.test="${IT_TESTS}" -DfailIfNoTests=false -DargLine="-Xmx2g" \
+            2>&1 | tee "logs/logs-${{ steps.uuid.outputs.uuid }}-layer2.out" || true
 
           zip -r "ie-tests/logs-${{ steps.uuid.outputs.uuid }}.zip" logs
+
       - name: Upload locally built artifact
         uses: actions/upload-artifact@v4
         continue-on-error: true
@@ -201,7 +130,7 @@ jobs:
   validation:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    needs: [test_nifi, system_tests]
+    needs: test_nifi
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test-nifi.yaml
+++ b/.github/workflows/test-nifi.yaml
@@ -82,7 +82,7 @@ jobs:
           # Before merge: delete the hardcoded line below and uncomment this one.
           # ARTIFACTORY_URL: ${{ secrets.NIFI_ARTIFACTORY_URL }}
           ARTIFACTORY_URL: "https://canonical.jfrog.io/artifactory/dataplatform-nifi-staging/"
-          CORE_MODULES: "nifi-commons/nifi-utils,nifi-commons/nifi-record,nifi-commons/nifi-expression-language,nifi-commons/nifi-record-path,nifi-framework-bundle/nifi-framework/nifi-framework-core"
+          CORE_MODULES: "nifi-commons/nifi-utils,nifi-commons/nifi-record,nifi-commons/nifi-expression-language,nifi-commons/nifi-record-path,nifi-commons/nifi-security-crypto-key,nifi-commons/nifi-property-encryptor,nifi-commons/nifi-security-cert,nifi-commons/nifi-security-ssl,nifi-framework-bundle/nifi-framework/nifi-framework-core"
         run: |
           echo "Java:"; java -version
           cd charmed-nifi
@@ -114,10 +114,94 @@ jobs:
           name: integration-test-logs-${{ steps.uuid.outputs.uuid }}
           path: charmed-nifi/ie-tests/logs-${{ steps.uuid.outputs.uuid }}.zip
 
+  # Layer 2 — single-node system/integration smoke: builds NiFi and boots real instances
+  # to run flows (maven-failsafe *IT). Separate job so its weight/flakiness can't mask
+  # Layer 1. Curated single-node set only — clustering/stateless/python ITs are excluded
+  # (the rock is single-node, so those are zero-signal and the flakiest part of the suite).
+  system_tests:
+    needs: prepare_matrix
+    runs-on: ["self-hosted-linux-amd64-jammy-xlarge"]
+    timeout-minutes: 1440
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{fromJson(needs.prepare_matrix.outputs.matrix)}}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+      - name: Install dependencies
+        run: |
+          sudo snap install yq
+          sudo apt-get update
+          sudo apt-get -y install zip
+      - name: ssh agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_KEY }}
+      - name: Clone repo
+        run: |
+          ssh-keyscan -t rsa git.launchpad.net >> ~/.ssh/known_hosts
+          git clone --progress --verbose ${{ secrets.REPO_NIFI_URL }}
+          cp -r ie-tests charmed-nifi
+      - name: Generate uuid
+        id: uuid
+        timeout-minutes: 5
+        run: echo "uuid=$(uuidgen)" >> $GITHUB_OUTPUT
+      - name: Setup maven credential
+        run: |
+          mkdir -p ~/.m2
+          mv ie-tests/settings.xml ~/.m2/settings.xml
+      - name: Run system tests
+        timeout-minutes: 600
+        env:
+          USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          # TEMP staging URL (same as Layer 1) — revert to secrets.NIFI_ARTIFACTORY_URL before merge.
+          ARTIFACTORY_URL: "https://canonical.jfrog.io/artifactory/dataplatform-nifi-staging/"
+          SUITE: "nifi-system-tests/nifi-system-test-suite"
+          # Absolute-necessary single-node smoke: boot NiFi + run basic processor flows.
+          # Widen as it stabilises; keep clustering/stateless/python OUT.
+          IT_TESTS: "RunOnceIT,RetryIT,ProcessorDynamicPropertiesIT,VerifiableProcessorSystemIT"
+        run: |
+          echo "Java:"; java -version
+          cd charmed-nifi
+          branch=${{ matrix.branch }}
+          [ -z "$branch" ] && branch="release-2.10.0-ubuntu0"
+          echo "Branch to test: $branch"
+          git checkout "$branch"
+          ./mvnw -version
+          echo "ie-tests/*" >> .rat-excludes
+          echo "**/ie-tests/*" >> .rat-excludes
+          echo "lp/*" >> .rat-excludes
+          mkdir -p logs
+
+          echo "### Building the system-test-suite + its NiFi deps (-DskipTests) ###"
+          ./mvnw -B -T1C -U -DskipTests -Drat.skip=true -pl "${SUITE}" -am install
+
+          echo "### Running Layer 2 single-node integration smoke ###"
+          # failsafe *IT tests; -fn so the validator sees all results; JVM capped for the forks.
+          ./mvnw -B -U -fn verify -pl "${SUITE}" \
+            -Dit.test="${IT_TESTS}" -DfailIfNoTests=false \
+            -DargLine="-Xmx2g" \
+            2>&1 | tee "logs/logs-${{ steps.uuid.outputs.uuid }}-systest.out"
+
+          zip -r "ie-tests/logs-${{ steps.uuid.outputs.uuid }}.zip" logs
+      - name: Upload locally built artifact
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        with:
+          name: integration-test-logs-${{ steps.uuid.outputs.uuid }}
+          path: charmed-nifi/ie-tests/logs-${{ steps.uuid.outputs.uuid }}.zip
+
   validation:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    needs: test_nifi
+    needs: [test_nifi, system_tests]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test-nifi.yaml
+++ b/.github/workflows/test-nifi.yaml
@@ -102,19 +102,15 @@ jobs:
 
           mkdir -p logs
 
-          # Build core modules + the system-test suite ONCE (no tests) — one clone, one build,
-          # reused by both layers (flink's build-once-then-test-groups pattern).
           echo "### Building core + system-test suite (-DskipTests) ###"
           ./mvnw -B -T1C -U -DskipTests -Drat.skip=true -pl "${CORE_MODULES},${SUITE}" -am install
 
-          # Layer 1 — unit tests on core modules.
           echo "### Layer 1: core unit tests ###"
           ./mvnw -B -U test -fn -pl "${CORE_MODULES}" 2>&1 | tee "logs/logs-${{ steps.uuid.outputs.uuid }}-layer1.out"
 
-          # Layer 2 — single-node system integration smoke (boots real NiFi). Best-effort:
-          # '|| true' keeps a Layer 2 build/staging failure from dropping Layer 1's results.
           echo "### Layer 2: single-node system integration smoke ###"
           ./mvnw -B -U -fn verify -pl "${SUITE}" \
+            -Pintegration-tests -Pskip-unit-tests \
             -Dit.test="${IT_TESTS}" -DfailIfNoTests=false -DargLine="-Xmx2g" \
             2>&1 | tee "logs/logs-${{ steps.uuid.outputs.uuid }}-layer2.out" || true
 

--- a/.github/workflows/test-nifi.yaml
+++ b/.github/workflows/test-nifi.yaml
@@ -35,10 +35,10 @@ jobs:
         branch: ${{fromJson(needs.prepare_matrix.outputs.matrix)}}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
@@ -113,7 +113,7 @@ jobs:
           zip -r "ie-tests/logs-${{ steps.uuid.outputs.uuid }}.zip" logs
 
       - name: Upload locally built artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: integration-test-logs-${{ steps.uuid.outputs.uuid }}
@@ -125,9 +125,9 @@ jobs:
     needs: test_nifi
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Checkout results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: results/
           pattern: integration-test-logs-*
@@ -143,7 +143,7 @@ jobs:
           zip -r all-results.zip results
           echo "END"
       - name: Upload all tests logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: integration-test-logs-uuid
           path: all-results.zip

--- a/ie-tests/validate_nifi.py
+++ b/ie-tests/validate_nifi.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""NiFi integration test validation module."""
+
+import os
+import re
+import tempfile
+import zipfile
+from argparse import ArgumentParser, Namespace
+
+from prettytable import PrettyTable
+
+from .utils import remove_ascii_colors
+from .validate import LogParser, Report
+
+SUMMARY_RE = re.compile(
+    r"Tests run:\s*(\d+),\s*Failures:\s*(\d+),\s*Errors:\s*(\d+),\s*Skipped:\s*(\d+)"
+)
+
+
+def parse_args() -> Namespace:
+    """Parse command line args."""
+    parser = ArgumentParser()
+    parser.add_argument(
+        "-a", "--archive-logs", help="Path to the archive where run logs are stored."
+    )
+    return parser.parse_args()
+
+
+class NifiLogParser(LogParser):
+    """Parser for the NiFi (JUnit/Surefire) integration tests."""
+
+    def parse_log_archive(self, log_archive: str) -> Report:
+        """Parse the log archive and extract the test results."""
+        filename = None
+        succeeded = failed = errors = skipped = total = 0
+        clean_lines = []
+        failed_tests = []
+        executed_modules = []
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            print("created temporary directory", tmpdirname)
+            with zipfile.ZipFile(log_archive, "r") as zip_ref:
+                zip_ref.extractall(tmpdirname)
+                log_directory = f"{tmpdirname}/logs/"
+                for log_file in os.listdir(log_directory):
+                    if ".out" not in log_file:
+                        continue
+                    filename = log_file
+                    print("Analyzed log file: " + log_file)
+                    with open(f"{log_directory}/{log_file}", "r") as file:
+                        for line in file:
+                            clean_line = remove_ascii_colors(line.strip())
+                            clean_lines.append(clean_line)
+
+                            if (
+                                "<<< FAILURE!" in clean_line
+                                or "<<< ERROR!" in clean_line
+                            ):
+                                failed_tests.append(clean_line)
+
+                            if clean_line.startswith("Building nifi"):
+                                executed_modules.append(clean_line.split(" ")[1])
+
+                            if "Time elapsed" in clean_line or "-- in" in clean_line:
+                                continue
+                            m = SUMMARY_RE.search(clean_line)
+                            if m:
+                                run, f, e, s = (int(g) for g in m.groups())
+                                total += run
+                                failed += f
+                                errors += e
+                                skipped += s
+
+        succeeded = total - failed - errors - skipped
+        return Report(
+            log_file=filename,
+            succeeded=succeeded,
+            failures=failed,
+            errors=errors,
+            skipped=skipped,
+            total=total,
+            executed_modules=executed_modules,
+            raw=clean_lines,
+            failed_tests=failed_tests,
+        )  # type: ignore
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    log_reports = []
+    zip_file_folder = args.archive_logs
+    print("Start analyze the logs from the different runs...")
+    logs_archives = os.listdir(zip_file_folder)
+    print(f"Number of runs: {len(logs_archives)}")
+    parser = NifiLogParser()
+    for log_archive in logs_archives:
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            print("created temporary directory", tmpdirname)
+            log_archive_path = f"{zip_file_folder}/{log_archive}"
+            res = parser.parse_log_archive(log_archive_path)
+            log_reports.append(res)
+            with open(f"/tmp/cleaned_{log_archive}", "w") as f:
+                for line in res.raw:
+                    f.write(f"{line}\n")
+
+    table = PrettyTable()
+    table.field_names = [
+        "Test",
+        "Succeeded",
+        "Failures",
+        "Errors",
+        "Skipped",
+        "Total",
+        "Executed test modules",
+        "Failed Tests",
+    ]
+    for report in log_reports:
+        table.add_row(
+            [
+                report.log_file,
+                report.succeeded,
+                report.failures,
+                report.errors,
+                report.skipped,
+                report.total,
+                len(report.executed_modules),
+                len(report.failed_tests),
+            ]
+        )
+    print(table)
+
+    print("\n\nFailed tests:")
+    for report in log_reports:
+        print("-" * 75)
+        print(f"Filename: {report.log_file}")
+        print(f"Number of failed tests: {len(report.failed_tests)}")
+        print("=" * 75)
+        for failed_test in report.failed_tests:
+            print(f"\t {failed_test}")
+        print("-" * 75)
+    print("End of the process.")

--- a/ie-tests/validate_nifi.py
+++ b/ie-tests/validate_nifi.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 """NiFi integration test validation module."""
 

--- a/products.json
+++ b/products.json
@@ -167,5 +167,19 @@
     "artifactory-user": "ARTIFACTORY_USER",
     "artifactory-token": "ARTIFACTORY_TOKEN",
     "tarball-regex": "polaris-*.tgz"
+  },
+  {
+    "name": "nifi",
+    "lp-building-project": "soss",
+    "lp-releasing-project": "nifi-releases",
+    "lp-building-repo": "~workflows-charmers/soss/+source/charmed-nifi/+git/charmed-nifi/",
+    "lp-building-branch-prefix": "lp-2",
+    "lp-consumer-key": "LP_CONSUMER_KEY",
+    "lp-access-token": "LP_ACCESS_TOKEN",
+    "lp-access-secret": "LP_SECRET_TOKEN",
+    "artifactory-url": "https://canonical.jfrog.io/artifactory/dataplatform-nifi-stable-local/",
+    "artifactory-user": "ARTIFACTORY_USER",
+    "artifactory-token": "ARTIFACTORY_TOKEN",
+    "tarball-regex": "nifi-*-bin.tar.gz"
   }
 ]


### PR DESCRIPTION
Onboards Apache NiFi 2.10.0 into central-uploader. This adds the product's integration-test workflow, a result
validator, and its products.json entry so NiFi can be tested and released through the SOSS/JSTM pipeline.