### PR TITLE
patch: Add OpenSearch dashboards 3.x / 2.x and OS 2.x with support to amd/arm

### DIFF
--- a/.github/workflows/check-new-releases-non-java.yaml
+++ b/.github/workflows/check-new-releases-non-java.yaml
@@ -52,8 +52,7 @@ on:
         type: string
         description: Architecture of that file
       series:
-        required: false
-        default: ""
+        required: true
         type: string
         description: Ubuntu series of that file
 
@@ -113,13 +112,20 @@ jobs:
       - name: Check if products needed to be released
         id: check-release
         run: |
+          # if series not specified, set it to empty string
+          if [ -z "${{ inputs.series }}" ]; then
+            echo "Series not specified, setting it to empty string"
+            series=""
+          else
+            series="${{ inputs.series }}"
+          fi
           python3 -m uploader.services \
             check-releases \
             --output-directory ${{ env.OUTPUT_DIR }} \
             --tarball-pattern ${{ inputs.tarball-regex }} \
             --repository-owner canonical \
             --project-name ${{ github.event.repository.name }} \
-            --series ${{ inputs.series }} \
+            --series $series \
             --architecture ${{ inputs.architecture }}
           
           cd ${{ env.OUTPUT_DIR }};

--- a/.github/workflows/check-new-releases-non-java.yaml
+++ b/.github/workflows/check-new-releases-non-java.yaml
@@ -114,19 +114,23 @@ jobs:
         run: |
           # if series not specified, set it to empty string
           if [ -z "${{ inputs.series }}" ]; then
-            echo "Series not specified, setting it to empty string"
-            series=""
+            python3 -m uploader.services \
+              check-releases \
+              --output-directory ${{ env.OUTPUT_DIR }} \
+              --tarball-pattern ${{ inputs.tarball-regex }} \
+              --repository-owner canonical \
+              --project-name ${{ github.event.repository.name }} \
+              --architecture ${{ inputs.architecture }}
           else
-            series="${{ inputs.series }}"
+            python3 -m uploader.services \
+              check-releases \
+              --output-directory ${{ env.OUTPUT_DIR }} \
+              --tarball-pattern ${{ inputs.tarball-regex }} \
+              --repository-owner canonical \
+              --project-name ${{ github.event.repository.name }} \
+              --series ${{ inputs.series }} \
+              --architecture ${{ inputs.architecture }}
           fi
-          python3 -m uploader.services \
-            check-releases \
-            --output-directory ${{ env.OUTPUT_DIR }} \
-            --tarball-pattern ${{ inputs.tarball-regex }} \
-            --repository-owner canonical \
-            --project-name ${{ github.event.repository.name }} \
-            --series $series \
-            --architecture ${{ inputs.architecture }}
           
           cd ${{ env.OUTPUT_DIR }};
           number_of_releases=$( ls . | wc -l )

--- a/.github/workflows/check-new-releases-non-java.yaml
+++ b/.github/workflows/check-new-releases-non-java.yaml
@@ -203,7 +203,11 @@ jobs:
           echo "TARBALL_FILENAME=$tarball_filename" >> $GITHUB_OUTPUT
           cd ../../
           ls
-          version=$( python3 -m uploader.services get-version-multiarch -n $tarball_filename --series ${{ inputs.series }} --architecture ${{ inputs.architecture }})
+          if [ -z "${{ inputs.series }}" ]; then
+            version=$( python3 -m uploader.services get-version-multiarch -n $tarball_filename --architecture ${{ inputs.architecture }})
+          else
+            version=$( python3 -m uploader.services get-version-multiarch -n $tarball_filename --series ${{ inputs.series }} --architecture ${{ inputs.architecture }})
+          fi
           lp_version=$(echo $version | cut -d'-' -f2-)
           track="${{ inputs.lp-release-track-name }}"
 

--- a/.github/workflows/check-new-releases-non-java.yaml
+++ b/.github/workflows/check-new-releases-non-java.yaml
@@ -52,7 +52,8 @@ on:
         type: string
         description: Architecture of that file
       series:
-        required: true
+        required: false
+        default: ""
         type: string
         description: Ubuntu series of that file
 

--- a/non-java-products.json
+++ b/non-java-products.json
@@ -121,5 +121,38 @@
         "check-all-runs": true,
         "series": "",
         "architecture": "amd64"
+    },
+    {
+        "name": "opensearch-dashboards",
+        "lp-building-project": "soss",
+        "lp-releasing-project": "opensearch-dashboards-releases",
+        "lp-building-repo": "~data-platform/soss/+source/opensearch-build/+git/opensearch-build/",
+        "lp-building-branch-prefix": "lp-dashboards-2",
+        "lp-release-track-name": "2.x",
+        "lp-consumer-key": "LP_CONSUMER_KEY",
+        "lp-access-token": "LP_ACCESS_TOKEN",
+        "lp-access-secret": "LP_SECRET_TOKEN",
+        "tarball-regex": "opensearch-dashboards-*-arm64.tar.gz",
+        "check-all-runs": true,
+        "series": "",
+        "architecture": "arm64"
+    },
+    {
+        "name": "opensearch-dashboards",
+        "lp-building-project": "soss",
+        "lp-releasing-project": "opensearch-dashboards-releases",
+        "lp-building-repo": "~data-platform/soss/+source/opensearch-build/+git/opensearch-build/",
+        "lp-building-branch-prefix": "lp-dashboards-2",
+        "lp-release-track-name": "2.x",
+        "lp-consumer-key": "LP_CONSUMER_KEY",
+        "lp-access-token": "LP_ACCESS_TOKEN",
+        "lp-access-secret": "LP_SECRET_TOKEN",
+        "artifactory-url": "https://canonical.jfrog.io/artifactory/dataplatform-opensearch-maven-local/",
+        "artifactory-user": "ARTIFACTORY_USER",
+        "artifactory-token": "ARTIFACTORY_TOKEN",
+        "tarball-regex": "opensearch-dashboards-*-x64.tar.gz",
+        "check-all-runs": true,
+        "series": "",
+        "architecture": "amd64"
     }
 ]

--- a/non-java-products.json
+++ b/non-java-products.json
@@ -101,6 +101,7 @@
         "lp-access-secret": "LP_SECRET_TOKEN",
         "tarball-regex": "opensearch-dashboards-*-arm64.tar.gz",
         "check-all-runs": true,
+        "series": "",
         "architecture": "arm64"
     },
     {
@@ -118,6 +119,7 @@
         "artifactory-token": "ARTIFACTORY_TOKEN",
         "tarball-regex": "opensearch-dashboards-*-x64.tar.gz",
         "check-all-runs": true,
+        "series": "",
         "architecture": "amd64"
     }
 ]

--- a/non-java-products.json
+++ b/non-java-products.json
@@ -101,7 +101,6 @@
         "lp-access-secret": "LP_SECRET_TOKEN",
         "tarball-regex": "opensearch-dashboards-*-arm64.tar.gz",
         "check-all-runs": true,
-        "series": "",
         "architecture": "arm64"
     },
     {
@@ -119,7 +118,6 @@
         "artifactory-token": "ARTIFACTORY_TOKEN",
         "tarball-regex": "opensearch-dashboards-*-x64.tar.gz",
         "check-all-runs": true,
-        "series": "",
         "architecture": "amd64"
     }
 ]

--- a/non-java-products.json
+++ b/non-java-products.json
@@ -88,5 +88,36 @@
         "check-all-runs": true,
         "architecture": "arm64",
         "series": "noble"
+    },
+    {
+        "name": "opensearch-dashboards",
+        "lp-building-project": "soss",
+        "lp-releasing-project": "opensearch-dashboards-releases",
+        "lp-building-repo": "~data-platform/soss/+source/opensearch-build/+git/opensearch-build/",
+        "lp-building-branch-prefix": "lp-dashboards-3",
+        "lp-release-track-name": "3.x",
+        "lp-consumer-key": "LP_CONSUMER_KEY",
+        "lp-access-token": "LP_ACCESS_TOKEN",
+        "lp-access-secret": "LP_SECRET_TOKEN",
+        "tarball-regex": "opensearch-dashboards-*-arm64.tar.gz",
+        "check-all-runs": true,
+        "architecture": "arm64"
+    },
+    {
+        "name": "opensearch-dashboards",
+        "lp-building-project": "soss",
+        "lp-releasing-project": "opensearch-dashboards-releases",
+        "lp-building-repo": "~data-platform/soss/+source/opensearch-build/+git/opensearch-build/",
+        "lp-building-branch-prefix": "lp-dashboards-3",
+        "lp-release-track-name": "3.x",
+        "lp-consumer-key": "LP_CONSUMER_KEY",
+        "lp-access-token": "LP_ACCESS_TOKEN",
+        "lp-access-secret": "LP_SECRET_TOKEN",
+        "artifactory-url": "https://canonical.jfrog.io/artifactory/dataplatform-opensearch-maven-local/",
+        "artifactory-user": "ARTIFACTORY_USER",
+        "artifactory-token": "ARTIFACTORY_TOKEN",
+        "tarball-regex": "opensearch-dashboards-*-x64.tar.gz",
+        "check-all-runs": true,
+        "architecture": "amd64"
     }
 ]

--- a/products.json
+++ b/products.json
@@ -150,7 +150,7 @@
     "lp-building-project": "soss",
     "lp-releasing-project": "opensearch-releases",
     "lp-building-repo": "~data-platform/soss/+source/opensearch-build/+git/opensearch-build/",
-    "lp-building-branch-prefix": "lp-2.1",
+    "lp-building-branch-prefix": "lp-2",
     "lp-release-track-name": "2",
     "lp-consumer-key": "LP_CONSUMER_KEY",
     "lp-access-token": "LP_ACCESS_TOKEN",
@@ -158,7 +158,26 @@
     "artifactory-url": "https://canonical.jfrog.io/artifactory/dataplatform-opensearch-maven-local/",
     "artifactory-user": "ARTIFACTORY_USER",
     "artifactory-token": "ARTIFACTORY_TOKEN",
-    "tarball-regex": "opensearch-*.tar.gz"
+    "tarball-regex": "opensearch-*-arm64.tar.gz",
+    "check-all-runs": true,
+    "architecture": "arm64"
+  },
+  {
+    "name": "opensearch",
+    "lp-building-project": "soss",
+    "lp-releasing-project": "opensearch-releases",
+    "lp-building-repo": "~data-platform/soss/+source/opensearch-build/+git/opensearch-build/",
+    "lp-building-branch-prefix": "lp-2",
+    "lp-release-track-name": "2",
+    "lp-consumer-key": "LP_CONSUMER_KEY",
+    "lp-access-token": "LP_ACCESS_TOKEN",
+    "lp-access-secret": "LP_SECRET_TOKEN",
+    "artifactory-url": "https://canonical.jfrog.io/artifactory/dataplatform-opensearch-maven-local/",
+    "artifactory-user": "ARTIFACTORY_USER",
+    "artifactory-token": "ARTIFACTORY_TOKEN",
+    "tarball-regex": "opensearch-*-x64.tar.gz",
+    "check-all-runs": true,
+    "architecture": "amd64"
   },
   {
     "name": "opensearch-plugin-prometheus-exporter",


### PR DESCRIPTION
This Pull Request add following products:
- OpenSearch Dashboards 3.x and 2.x to the non-java-products.
- OpenSearch 2.x to the java-products. OpenSearch was already present but it didn't support multiple architecture. With this PR it now supports.